### PR TITLE
Add max-retries option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ tar zc mydir | stdin2glacier - -r eu-central-1 -v myvault -d "The mydir archive"
     -v, --vault-name <vault-name>    Vault name
     -d, --description <description>  Archive description
     -k, --skip-parts <skip-parts>    Retry upload but skip all previously uploaded parts before given part number
+    -m, --max-retries <max-retries>  Number of times to retry a request to AWS before giving up (defaults to 0)
 ```
 
 ## requirements

--- a/index.js
+++ b/index.js
@@ -20,11 +20,13 @@ program
     .option('-v, --vault-name <vault-name>', 'Vault name')
     .option('-d, --description <description>', 'Archive description')
     .option('-k, --skip-parts <skip-parts>', 'Retry upload but skip all previously uploaded parts before given part number')
+    .option('-m, --max-retries <max-retries>', 'Number of times to retry a request to AWS before giving up (defaults to 0)')
     //.option('--dry-run', 'Do not actually upload anything, just simulate')
     .action((file) => {
         AWS.config.region = program.region;
         AWS.config.apiVersions.glacier = '2012-06-01';
         AWS.config.httpOptions.timeout = 300000;
+        AWS.config.maxRetries = parseInt(program.maxRetries) || 0;
         /* global ok */ glacier = new AWS.Glacier();
         doUpload(file);
     })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stdin2glacier",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "AWS Glacier upload tool with pipelines",
   "bin": {
     "stdin2glacier": "./index.js"


### PR DESCRIPTION
Allows the end user to sets the aws-sdk maxRetries configuration point.

Defaults to 0 - existing behavior.

More info: https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/global-config-object.html